### PR TITLE
EGATE-71: Repackage event-gateway spring-boot jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,16 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>exec</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The configuration will generate two artifacts:
    1. alfresco-event-gateway-\<version\>.jar  (to be used as a dependency of another module)
    2. alfresco-event-gateway-\<version\>-exec.jar  (spring-boot executable jar)