### PR TITLE
Egate 74: Modify MetricsController path

### DIFF
--- a/src/main/java/org/alfresco/event/gateway/metrics/MetricsController.java
+++ b/src/main/java/org/alfresco/event/gateway/metrics/MetricsController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Jamal Kaabi-Mofrad
  */
 @RestController
-@RequestMapping("/alfresco/api/messaging/versions/1")
+@RequestMapping("/camel")
 public class MetricsController
 {
     private final CamelContext camelContext;

--- a/src/test/java/org/alfresco/event/gateway/services/rest/EventTopicControllerTest.java
+++ b/src/test/java/org/alfresco/event/gateway/services/rest/EventTopicControllerTest.java
@@ -22,7 +22,7 @@ public class EventTopicControllerTest
     @Test
     public void getEventGlobalTopicFails() throws Exception
     {
-        ResponseEntity<?> response = eventTopicController.getEventGlobalTopic();        
+        ResponseEntity<?> response = eventTopicController.getEventGlobalTopic();
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("alfresco.events.allEvents", ((EventTopicEntity)((JsonBodyContentEntry<?>)response.getBody()).getEntry()).getEventTopic());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,1 +1,0 @@
-# Spring boot workaround: An empty file, in order to override the application.yml file from the main source.


### PR DESCRIPTION
- Fixed the controller path.
- Fixed tests failure caused by EGATE-32.

Note: The custom camel metrics is disabled by default (to be consistent with the spring-boot default settings)
