### PR TITLE
EGATE-92: Updated the tests to reflect the acs-events-consolidator changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <java.version>1.8</java.version>
 
         <dependency.camel.version>2.22.0</dependency.camel.version>
-        <dependency.event-model.version>0.0.1</dependency.event-model.version>
+        <dependency.event-model.version>0.0.2</dependency.event-model.version>
         <dependency.commons.validator.version>1.6</dependency.commons.validator.version>
     </properties>
 

--- a/src/main/java/org/alfresco/event/gateway/GatewayRoute.java
+++ b/src/main/java/org/alfresco/event/gateway/GatewayRoute.java
@@ -59,9 +59,7 @@ public class GatewayRoute extends RouteBuilder
         from(fromRouteProperties.getUri())
                     .unmarshal("publicDataFormat")
                     .choice()
-                        .when(IS_EVENT_V1).bean("eventV1Enricher")
-                        .end()
-                    .marshal("publicDataFormat")
-                    .to(toRouteProperties.getUri());
+                        .when(IS_EVENT_V1).bean("eventV1Enricher").marshal("publicDataFormat").to(toRouteProperties.getUri())
+                        .end();
     }
 }

--- a/src/test/java/org/alfresco/event/gateway/AbstractCamelMockTest.java
+++ b/src/test/java/org/alfresco/event/gateway/AbstractCamelMockTest.java
@@ -142,7 +142,7 @@ public abstract class AbstractCamelMockTest
     }
 
     @Test
-    public void testRoute_RepositoryPublicEvents() throws Exception
+    public void testRoute_TransactionPublicEvents() throws Exception
     {
         // Set the expected number of messages
         mockEndpoint.expectedMessageCount(2);

--- a/src/test/resources/events/enriched-authorityAddedToGroupEvent.json
+++ b/src/test/resources/events/enriched-authorityAddedToGroupEvent.json
@@ -5,9 +5,8 @@
   "principal": "admin",
   "resource": {
     "schema": "org.alfresco.event.model.acs.AuthorityResourceV1",
-    "id": "86525ef4-6c7c-4e82-94f4-4687a736f392",
+    "id": "user2",
     "primaryHierarchy": [],
-    "authorityName": "user2",
     "parentGroup": "GROUP_TestGroup"
   }
 }

--- a/src/test/resources/events/enriched-authorityRemovedFromGroupEvent.json
+++ b/src/test/resources/events/enriched-authorityRemovedFromGroupEvent.json
@@ -5,9 +5,8 @@
   "principal": "admin",
   "resource": {
     "schema": "org.alfresco.event.model.acs.AuthorityResourceV1",
-    "id": "65195ef4-6c7c-4e82-94f4-4687a736fa47",
+    "id": "user2",
     "primaryHierarchy": [],
-    "authorityName": "user2",
     "parentGroup": "GROUP_TestGroup"
   }
 }

--- a/src/test/resources/events/enriched-groupDeletedEvent.json
+++ b/src/test/resources/events/enriched-groupDeletedEvent.json
@@ -5,9 +5,8 @@
   "principal": "admin",
   "resource": {
     "schema": "org.alfresco.event.model.acs.AuthorityResourceV1",
-    "id": "65195ef4-6c7c-4e82-94f4-4687a736fa47",
+    "id": "GROUP_TestGroup",
     "primaryHierarchy": [],
-    "authorityName": "GROUP_TestGroup",
     "cascade": true
   }
 }

--- a/src/test/resources/events/public-authorityAddedToGroupEvent.json
+++ b/src/test/resources/events/public-authorityAddedToGroupEvent.json
@@ -5,9 +5,8 @@
   "principal": "admin",
   "resource": {
     "schema": "org.alfresco.event.model.acs.AuthorityResourceV1",
-    "id": "86525ef4-6c7c-4e82-94f4-4687a736f392",
+    "id": "user2",
     "primaryHierarchy": [],
-    "authorityName": "user2",
     "parentGroup": "GROUP_TestGroup"
   }
 }

--- a/src/test/resources/events/public-authorityRemovedFromGroupEvent.json
+++ b/src/test/resources/events/public-authorityRemovedFromGroupEvent.json
@@ -5,9 +5,8 @@
   "principal": "admin",
   "resource": {
     "schema": "org.alfresco.event.model.acs.AuthorityResourceV1",
-    "id": "65195ef4-6c7c-4e82-94f4-4687a736fa47",
+    "id": "user2",
     "primaryHierarchy": [],
-    "authorityName": "user2",
     "parentGroup": "GROUP_TestGroup"
   }
 }

--- a/src/test/resources/events/public-groupDeletedEvent.json
+++ b/src/test/resources/events/public-groupDeletedEvent.json
@@ -5,9 +5,8 @@
   "principal": "admin",
   "resource": {
     "schema": "org.alfresco.event.model.acs.AuthorityResourceV1",
-    "id": "65195ef4-6c7c-4e82-94f4-4687a736fa47",
+    "id": "GROUP_TestGroup",
     "primaryHierarchy": [],
-    "authorityName": "GROUP_TestGroup",
     "cascade": true
   }
 }


### PR DESCRIPTION
- Updated the tests to reflect the acs-events-consolidator changes.
- Updated event-model version
- Changed the Route Builder to only route messages that are of type **_EventV1_** or its sub-type.