### PR TITLE
REPO-4977: Helm client version 3.x is not compatible with ACS helm charts

### DIFF
--- a/charts/alfresco-event-gateway/Chart.yaml
+++ b/charts/alfresco-event-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/java.png
 name: alfresco-event-gateway
-version: 0.1.0-SNAPSHOT
+version: 0.1.3

--- a/charts/alfresco-event-gateway/templates/deployment.yaml
+++ b/charts/alfresco-event-gateway/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       labels:
@@ -47,5 +51,4 @@ spec:
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- end }}

--- a/charts/alfresco-event-gateway/values.yaml
+++ b/charts/alfresco-event-gateway/values.yaml
@@ -38,3 +38,9 @@ readinessProbe:
   periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 1
+
+global:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0


### PR DESCRIPTION
- Remove unsupported k8s annotation terminationGracePeriodSeconds from chart and define RollingUpdate strategy